### PR TITLE
Added .env file for DB_URI for mongod

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 CS96 Dev Team first project -- a text-based communication tool, driven by Node.js
 
 *This repo autodeploys to https://cs96.tk*
+
+Before running, please ensure that you have a `.env` file in the root directory in the format `KEY=VALUE`, one per line. `.env` should contain the following keys:
+
+* DB_URI: an complete MongoDB connection URI

--- a/db/connect.js
+++ b/db/connect.js
@@ -9,7 +9,7 @@ const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
 
 // standard URI format: mongodb://[dbuser:dbpassword@]host:port/dbname
-const db_uri = ""; // load URI from environment variables later
+const db_uri = process.env.DB_URI; // load URI from environment variables
 
 // connect to the mlab instance
 var conn = mongoose.connection;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "CS96 Dev Team first project -- a text-based communication tool, driven by Node.js",
   "main": "server.js",
   "dependencies": {
+    "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "express-session": "^1.15.6",
     "express-socket.io-session": "^1.3.2",

--- a/scripts/restartnginx.sh
+++ b/scripts/restartnginx.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 service nginx restart > /var/log/restartapache.out 2>&1
 cd /var/www/html
+cp /home/ec2-user/.env .
 npm install
 pm2 restart server

--- a/scripts/startnginx.sh
+++ b/scripts/startnginx.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 service nginx start > /var/log/startnginx.out 2>&1
 cd /var/www/html
+cp /home/ec2-user/.env .
 npm install
 pm2 restart server

--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@
  * The main server dispatcher.
  *
  */
+ 
+require('dotenv').config();
 
 const {
   CONN_STATUS


### PR DESCRIPTION
We can now read various configuration strings, most notably the mongod connection uri, from a `.env` file at the root of the project.  The format of `.env` is as follows:

```
KEY1=VALUE1
KEY2=VALUE2
```

Then, process.env.KEY1 will be VALUE1, etc.

Note that `server.js` will *not* run without `.env` being present.