### PR TITLE
Fix pairing

### DIFF
--- a/matcher.js
+++ b/matcher.js
@@ -41,7 +41,7 @@ class Matcher {
     }
 
     // Add a new id into the connection pool
-    connect(id, username = +new Date(), user_id) {
+    connect(id, username, user_id) {
         // If id is empty, don't try to add it
         if (id === undefined || id === "" || user_id === undefined) {
             return;
@@ -106,7 +106,7 @@ class Matcher {
     // Hangup a still-connected user.
     hangup(id) {
         this.unpair(id)
-        this.addBlacklist(id, this.connections[id].partner)
+        this.addBlacklist(id, this.connections[id].partner);
         this.connections[id].partner = null;
         this._setStatus(id, WAITING);
         this.checkForMatches(id);

--- a/matcher.js
+++ b/matcher.js
@@ -41,7 +41,7 @@ class Matcher {
     }
 
     // Add a new id into the connection pool
-    connect(id, username, user_id) {
+    connect(id, username = +new Date(), user_id) {
         // If id is empty, don't try to add it
         if (id === undefined || id === "" || user_id === undefined) {
             return;

--- a/server.js
+++ b/server.js
@@ -126,7 +126,7 @@ io.sockets.on("connection", function (socket) {
     matcher.connect(socket.id, username, user_id);
     socket.handshake.session.username = username;
     socket.handshake.session.save();
-    socket.emit('recall username', username, user_id)
+    socket.emit('recall username', username)
   })
 
   socket.on("disconnect", () => {

--- a/server.js
+++ b/server.js
@@ -126,7 +126,7 @@ io.sockets.on("connection", function (socket) {
     matcher.connect(socket.id, username, user_id);
     socket.handshake.session.username = username;
     socket.handshake.session.save();
-    socket.emit('recall username', username)
+    socket.emit('recall username', username, user_id)
   })
 
   socket.on("disconnect", () => {

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -134,7 +134,7 @@
                 })
                 socket.emit("set user", {
                     username: user.facebook.name,
-                    fb_id: user.uuid
+                    user_id: user.uuid
                 })
                 socket.on("recall username", username => {
                     $identity.text("Hello, " + username);


### PR DESCRIPTION
There was a bug that kept matcher from ever getting a user's uuid (a variable in index.handlebars was misnamed). The bug currently prevents any users from pairing on the site. This fixes that bug.