### PR TITLE
Remove #_=_ from URL

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -37,6 +37,16 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js" integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js" integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ" crossorigin="anonymous"></script>
 
+    <script type="text/javascript">
+        // Test for strange url
+        if (window.location.hash == '#_=_'){
+            // Check if browser supports history.replaceState
+            history.replaceState 
+                // Replace the current page state with the clean URL
+                ? history.replaceState(null, null, window.location.href.split('#')[0])
+                : window.location.hash = '';
+        }
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
The Facebook authentication callback appends a fragment  "#_=_" sequence to the return URL. This is apparently [by design](https://developers.facebook.com/bugs/318390728250352/), but for our use case, it seems fine to remove it for aesthetic reasons. 

This PR replaces current page state with a clean URL. Slightly hacky and not an urgent merge, but putting it here for review. 