### PR TITLE
Fixed order of chats in chatHistory

### DIFF
--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -214,7 +214,8 @@
             contentType: 'application/json; charset=utf-8',
             url: '/profile/chats',
             success: res => {
-                console.log(res)
+                // put array in correct order with most recent at index 0
+                res.reverse();
 
                 // Double-check conversation count
                 if (res.length > $("#convo-count").text) {


### PR DESCRIPTION
Just a small fix that puts the chats in the right order